### PR TITLE
Prettier/faster code + sensible (?) defaults 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,7 @@
                                     :password      :env/clojars_pass
                                     :sign-releases false}]]
   :plugins [[lein-cljfmt "0.6.4"]]
+  :global-vars {*warn-on-reflection* true}
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.1"]
                                   [cheshire "5.10.0"]
                                   [com.cognitect/transit-clj "0.8.319"]

--- a/src/hato/client.clj
+++ b/src/hato/client.clj
@@ -159,12 +159,13 @@
   `request` is the map of request options output by `make-request`
   `response` is the raw HttpResponse"
   [{:keys [request ^HttpResponse response http-client]}]
-  {:uri         (.toString (.uri response))
+  {:uri         (str (.uri response))
    :status      (.statusCode response)
    :body        (.body response)
-   :headers     (->> (.map (.headers response))
-                     (map (fn [[k v]] (if (> (count v) 1) [k v] [k (first v)])))
-                     (into {}))
+   :headers     (->> response
+                     .headers
+                     .map
+                     (into {} (map (fn [[k v]] (if (> (count v) 1) [k v] [k (first v)])))))
    :version     (-> response .version .name Version->kw)
    :http-client http-client
    :request     (assoc request :http-request (.request response))})

--- a/src/hato/client.clj
+++ b/src/hato/client.clj
@@ -19,8 +19,8 @@
     (java.util.function Function Supplier)
     (java.io File InputStream)
     (clojure.lang ExceptionInfo)
-    (java.nio CharBuffer ByteBuffer)
-    (java.nio.charset CharsetEncoder CharsetDecoder Charset)))
+    (java.nio ByteBuffer)
+    (java.nio.charset  Charset)))
 
 (defn- ->Authenticator
   [v]

--- a/src/hato/client.clj
+++ b/src/hato/client.clj
@@ -238,9 +238,7 @@
            proxy
            ssl-context
            ssl-parameters
-           version]
-    :or {redirect-policy :normal ;; https to http not allowed
-         version :http-2}}]      ;; will fallback to version 1.1
+           version]}]
   (cond-> (HttpClient/newBuilder)
           connect-timeout (.connectTimeout (Duration/ofMillis connect-timeout))
           redirect-policy (.followRedirects (->Redirect redirect-policy))
@@ -283,8 +281,7 @@
            version
            expect-continue]
     :or   {request-method :get
-           scheme :https
-           timeout 2000} ;; a sensible default?
+           timeout 120000} ;; 2 minutes
     :as   req}]
   (cond-> (HttpRequest/newBuilder
             (URI. (str (name scheme)

--- a/src/hato/middleware.clj
+++ b/src/hato/middleware.clj
@@ -22,7 +22,6 @@
    (java.util.zip
     GZIPInputStream InflaterInputStream ZipException Inflater)))
 
-(set! *warn-on-reflection* true)
 
 ;; Cheshire is an optional dependency, so we check for it at compile time.
 
@@ -113,8 +112,9 @@
 
 (defn url-encode
   "Returns a UTF-8 URL encoded version of the given string."
-  [^String unencoded & [^String encoding]]
-  (URLEncoder/encode unencoded (or encoding "UTF-8")))
+  [^String unencoded & [encoding]]
+  (let [^String enc (or encoding "UTF-8")]
+    (URLEncoder/encode unencoded enc)))
 
 
 ;;;
@@ -140,8 +140,8 @@
      :server-port  (when-pos (.getPort url-parsed))
      :uri          (url-encode-illegal-characters (.getPath url-parsed))
      :url          url
-     :user-info    (when-let [user-info (.getUserInfo url-parsed)]
-                     (URLDecoder/decode user-info))
+     :user-info    (some-> (.getUserInfo url-parsed)
+                           (URLDecoder/decode "UTF-8")) ;; avoid deprecated methods!
      :query-string (url-encode-illegal-characters (.getQuery url-parsed))}))
 
 

--- a/src/hato/multipart.clj
+++ b/src/hato/multipart.clj
@@ -14,7 +14,7 @@
        (format "name=\"%s\"" (or part-name name))
        (when-let [fname (or file-name
                             (when (instance? File content)
-                              (.getName content)))]
+                              (.getName ^File content)))]
          (format "; filename=\"%s\"" fname))))
 
 (defn- content-type
@@ -23,7 +23,7 @@
        (cond
          content-type content-type
          (string? content) "text/plain; charset=UTF-8"
-         (instance? File content) (or (Files/probeContentType (.toPath content))
+         (instance? File content) (or (Files/probeContentType (.toPath ^File content))
                                       "application/octet-stream")
          :else "application/octet-stream")))
 

--- a/src/hato/websocket.clj
+++ b/src/hato/websocket.clj
@@ -6,8 +6,6 @@
            (java.nio ByteBuffer)
            (java.util.function Function)))
 
-(set! *warn-on-reflection* true)
-
 (defn request->WebSocketListener
   "Constructs a new WebSocket listener to receive events for a given WebSocket connection.
 
@@ -64,6 +62,14 @@
       (when on-error
         (on-error ws err)))))
 
+(defn- with-headers
+  ^WebSocket$Builder [builder headers]
+  (reduce-kv
+    (fn [^WebSocket$Builder b ^String hk ^String hv]
+      (.header b hk hv))
+    builder
+    headers))
+
 (defn websocket*
   "Same as `websocket` but take all arguments as a single map"
   [{:keys [uri
@@ -73,20 +79,17 @@
            connect-timeout
            subprotocols]
     :as opts}]
-  (let [^HttpClient http-client (if (instance? HttpClient http-client) http-client (HttpClient/newHttpClient))
-        ^WebSocket$Listener listener (if (instance? WebSocket$Listener listener) listener (request->WebSocketListener opts))]
-
-    (let [^WebSocket$Builder builder (.newWebSocketBuilder http-client)]
-      (doseq [[header-n header-v] headers]
-        (.header builder header-n header-v))
-
-      (when connect-timeout
-        (.connectTimeout builder (Duration/ofMillis connect-timeout)))
-
-      (when (seq subprotocols)
-        (.subprotocols builder (first subprotocols) (into-array String (rest subprotocols))))
-
-      (.buildAsync builder (URI/create uri) listener))))
+  (let [^HttpClient http-client (if (instance? HttpClient http-client)
+                                  http-client
+                                  (HttpClient/newHttpClient))
+        ^WebSocket$Listener listener (if (instance? WebSocket$Listener listener)
+                                       listener
+                                       (request->WebSocketListener opts))]
+    (cond-> (.newWebSocketBuilder http-client)
+            connect-timeout    (.connectTimeout (Duration/ofMillis connect-timeout))
+            (seq subprotocols) (.subprotocols (first subprotocols) (into-array String (rest subprotocols)))
+            headers            (with-headers headers)
+            true               (.buildAsync (URI/create uri) listener))))
 
 (defn websocket
   "Builds a new WebSocket connection from a request object and returns a future connection.

--- a/test/hato/client_test.clj
+++ b/test/hato/client_test.clj
@@ -38,7 +38,7 @@
           ":cookie-handler takes precedence over :cookie-policy")))
 
   (testing "redirect-policy"
-    (is (= HttpClient$Redirect/NORMAL (.followRedirects (build-http-client {}))) "NORMAL by default")
+    (is (= HttpClient$Redirect/NEVER (.followRedirects (build-http-client {}))) "NEVER by default")
     (are [expected option] (= expected (.followRedirects (build-http-client {:redirect-policy option})))
       HttpClient$Redirect/ALWAYS :always
       HttpClient$Redirect/NEVER :never
@@ -214,10 +214,10 @@
   ; Changed provider due to https://github.com/postmanlabs/httpbin/issues/617
   (let [redirect-to "https://httpbingo.org/get"
         uri (format "https://httpbingo.org/redirect-to?url=%s" redirect-to)]
-    (testing "normal redirect (default)"
+    (testing "no redirects (default)"
       (let [r (get uri {:as :string})]
-        (is (= 200 (:status r)))
-        (is (= redirect-to (:uri r)))))
+        (is (= 302 (:status r)))
+        (is (= uri (:uri r)))))
 
     (testing "explicitly never"
       (let [r (get uri {:as :string :http-client {:redirect-policy :never}})]

--- a/test/hato/middleware_test.clj
+++ b/test/hato/middleware_test.clj
@@ -284,7 +284,7 @@
 
   (testing "coercing to transit+json"
     (let [r ((wrap-form-params identity) {:form-params {:moo "cow boy!"} :request-method :post :content-type :transit+json})]
-      (is (= "[\"^ \",\"~:moo\",\"cow boy!\"]" (String. (:body r)))))))
+      (is (= "[\"^ \",\"~:moo\",\"cow boy!\"]" (String. ^bytes (:body r)))))))
 
 (deftest test-wrap-method
   (testing "when no method option"

--- a/test/hato/websocket_test.clj
+++ b/test/hato/websocket_test.clj
@@ -8,7 +8,7 @@
 
 (defn byte-buffer->byte-array
   "Converts a byte buffer to a byte array."
-  [^ByteBuffer buf]
+  ^bytes [^ByteBuffer buf]
   (let [bytes (byte-array (.remaining buf))]
     (.get buf bytes)
     bytes))
@@ -94,7 +94,7 @@
   (testing "server sends back pong on ping request."
     (let [ping-p (promise)
           pong-p (promise)]
-      (with-ws-server {:on-ping (fn [_ x]
+      (with-ws-server {:on-ping (fn [_ ^bytes x]
                                   (deliver ping-p (String. x "UTF-8")))}
         (let [ws @(websocket "ws://localhost:1234" {:on-pong (fn [_ msg]
                                                                (deliver pong-p (String. (byte-buffer->byte-array msg) "UTF-8")))})]


### PR DESCRIPTION
- Makes code more readable/idiomatic
- Removes reflective calls (only a few remain in tests)
- Adds sensible (?) defaults for request.timeout (2 seconds), request.scheme (HTTPS), client.redirect-policy (NORMAL) & client.version (HTTP2)
- Reworks tests that utilised defaults which changed (mainly the redirect-policy related ones)