### PR TITLE
Handle mixed-case content-encoding values for RFC2616 compliance

### DIFF
--- a/src/hato/middleware.clj
+++ b/src/hato/middleware.clj
@@ -600,7 +600,9 @@
 ;; Multimethods for Content-Encoding dispatch automatically
 ;; decompressing response bodies
 (defmulti decompress-body
-  (fn [resp] (get-in resp [:headers "content-encoding"])))
+  (fn [resp]
+    (when-let [encoding (get-in resp [:headers "content-encoding"])]
+      (str/lower-case encoding))))
 
 (defmethod decompress-body "gzip"
   [resp]

--- a/test/hato/middleware_test.clj
+++ b/test/hato/middleware_test.clj
@@ -149,6 +149,8 @@
     (are [response] (= "s" (-> ((wrap-decompression (constantly response)) {}) :body slurp))
       {:body (string->stream "s")}
       {:body (clojure.java.io/input-stream (gzip (.getBytes "s"))) :headers {"content-encoding" "gzip"}}
+      {:body (string->stream "s")}
+      {:body (clojure.java.io/input-stream (gzip (.getBytes "s"))) :headers {"content-encoding" "GZip"}}
                     ; TODO deflate
       ))
 


### PR DESCRIPTION
See #28 