### PR TITLE
expose executor configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ This can be done with `build-http-client`:
 
 `connect-timeout` Timeout to making a connection, in milliseconds (default: unlimited).
 
+`executor` Sets the thread executor.
+
 `redirect-policy` Sets the redirect policy.
 
   - `:never` (default) Never follow redirects.

--- a/project.clj
+++ b/project.clj
@@ -16,4 +16,5 @@
                                   [ring/ring-core "1.9.0"]
                                   [javax.servlet/servlet-api "2.5"]
                                   [com.cognitect/transit-clj "0.8.319"]
+                                  [funcool/promesa "6.0.0"]
                                   [http-kit "2.3.0"]]}})

--- a/src/hato/client.clj
+++ b/src/hato/client.clj
@@ -202,6 +202,7 @@
   `cookie-handler` a java.net.CookieHandler
   `cookie-policy` :none, :all, :original-server. cookie-handler takes precedence if specified
   `connect-timeout` in milliseconds
+  `executor` a java.util.concurrent.ThreadPoolExecutor
   `redirect-policy` :never (default), :normal, :always
   `priority` an integer between 1 and 256 inclusive for HTTP/2 requests
   `proxy` a java.net.ProxySelector or :no-proxy
@@ -212,6 +213,7 @@
            cookie-handler
            cookie-policy
            connect-timeout
+           executor
            redirect-policy
            priority
            proxy
@@ -220,6 +222,7 @@
            version]}]
   (cond-> (HttpClient/newBuilder)
     connect-timeout (.connectTimeout (Duration/ofMillis connect-timeout))
+    executor (.executor executor)
     redirect-policy (.followRedirects (->Redirect redirect-policy))
     priority (.priority priority)
     proxy (.proxy (->ProxySelector proxy))


### PR DESCRIPTION
This small patch exposes `executor` option for `build-http-client`, so that users can set their own thread executor instance. 

fixes: https://github.com/gnarroway/hato/issues/9