### PR TITLE
Handle missing content-type header in response

### DIFF
--- a/src/hato/conversion.clj
+++ b/src/hato/conversion.clj
@@ -38,7 +38,7 @@
                     (:content-type resp)))))
 
   ; Return strings for text, or the original result otherwise.
-  (if (= "text" (namespace content-type))
+  (if (= "text" (and content-type (namespace content-type)))
     (let [^String charset (or (-> resp :content-type-params :charset) "UTF-8")]
       (slurp (:body resp) :encoding charset))
     (:body resp)))

--- a/test/hato/middleware_test.clj
+++ b/test/hato/middleware_test.clj
@@ -81,7 +81,7 @@
   (testing "with basic-auth option"
     (let [r ((wrap-basic-auth identity) {:basic-auth {:user "username" :pass "password"}})]
       (is (not (contains? r :basic-auth)))
-      (is (= (get-in r [:headers "authorization"]))))))
+      (is (= "Basic dXNlcm5hbWU6cGFzc3dvcmQ=" (get-in r [:headers "authorization"]))))))
 
 (deftest test-wrap-oauth
   (testing "with no oauth-token option"
@@ -215,6 +215,10 @@
     (are [input type] (= input (-> ((wrap-output-coercion (constantly {:headers {"content-type" type} :body (string->stream input)})) {:as :auto}) :body))
       "<html>Hello</html>" "text/html"
       "hello,world" "text/csv"))
+
+  (testing "leaves bodies without content-type alone"
+    (let [body (string->stream "hello")]
+      (is (= body (-> ((wrap-output-coercion (constantly {:body body})) {:as :auto}) :body)))))
 
   (testing "clojure coercions"
     (is (= {:a 1} (-> ((wrap-output-coercion (constantly {:status 200 :body (string->stream "{:a 1}")})) {:as :clojure}) :body))))


### PR DESCRIPTION
Hi,

Thanks for making hato, I'm enjoying using it. I've added it as an [implementation for martian](https://github.com/oliyh/martian/tree/master/hato)!

When setting `:as :auto` if the response does not contain a Content-Type header then hato blows up trying to read the namespace of the content type keyword. This prevents that happening.

Also added a drive-by of a test assertion that was calling `=` with only one argument.

Cheers,
Oliy