### PR TITLE
Consider custom data readers when coercing Clojure body

### DIFF
--- a/src/hato/middleware.clj
+++ b/src/hato/middleware.clj
@@ -188,7 +188,8 @@
 (defn coerce-clojure-body
   [_ {:keys [body] :as resp}]
   (let [^String charset (or (-> resp :content-type-params :charset) "UTF-8")]
-    (assoc resp :body (edn/read-string (slurp body :encoding charset)))))
+    (assoc resp :body (edn/read-string {:readers *data-readers*}
+                                       (slurp body :encoding charset)))))
 
 (defn coerce-transit-body
   [{:keys [transit-opts]} {:keys [body] :as resp} type]

--- a/test/hato/middleware_test.clj
+++ b/test/hato/middleware_test.clj
@@ -223,6 +223,10 @@
   (testing "clojure coercions"
     (is (= {:a 1} (-> ((wrap-output-coercion (constantly {:status 200 :body (string->stream "{:a 1}")})) {:as :clojure}) :body))))
 
+  (testing "clojure coercions considers custom data readers"
+    (binding [*data-readers* {'my/reader #'identity}]
+      (is (= {:a 1} (-> ((wrap-output-coercion (constantly {:status 200 :body (string->stream "{:a #my/reader 1}")})) {:as :clojure}) :body)))))
+
   (testing "transit coercions"
     (are [expected as] (= expected (-> ((wrap-output-coercion (constantly {:status 200 :body (string->stream "[\"^ \",\"~:a\",[1,2]]")})) {:as as}) :body))
       {:a [1 2]} :transit+json))


### PR DESCRIPTION
By default, `clojure.edn/read-string` does not use `*data-readers*`.
This implies that user-defined data readers will not be used for
coercing bodies, and an exception will be thrown if the response
contains custom data readers.

Fixes https://github.com/gnarroway/hato/issues/45.