### PR TITLE
Don't swallow exceptions in parsing transit+json

### DIFF
--- a/src/hato/conversion.clj
+++ b/src/hato/conversion.clj
@@ -62,11 +62,13 @@
                         (with-open [^InputStream bs (:body resp)]
                           (try
                             (read (reader bs type (-> opts :transit-opts :decode)))
-                            (catch RuntimeException _
-                              ; https://github.com/gnarroway/hato/issues/25
-                              ; explicitly handle case where stream is empty
-                              ; since .available seems to always return 0 on JDK11 (but not 15).
-                              nil))))]
+                            (catch RuntimeException e
+                              ;; https://github.com/gnarroway/hato/issues/25
+                              ;; explicitly handle case where stream is empty
+                              ;; since .available seems to always return 0 on JDK11 (but not 15).
+                              (if (not= java.io.EOFException (class (.getCause e)))
+                                (throw e)
+                                nil)))))]
 
     (defmethod decode :application/transit+json [resp opts]
       (parse-transit :json resp opts))

--- a/src/hato/middleware.clj
+++ b/src/hato/middleware.clj
@@ -48,11 +48,13 @@
         read (ns-resolve 'cognitect.transit 'read)]
     (try
       (read (reader in type (:decode opts)))
-      (catch RuntimeException _
-        ; https://github.com/gnarroway/hato/issues/25
-        ; explicitly handle case where stream is empty
-        ; since .available seems to always return 0 on JDK11 (but not 15).
-        nil))))
+      (catch RuntimeException e
+        ;; https://github.com/gnarroway/hato/issues/25
+        ;; explicitly handle case where stream is empty
+        ;; since .available seems to always return 0 on JDK11 (but not 15).
+        (if (not= java.io.EOFException (class (.getCause e)))
+          (throw e)
+          nil)))))
 
 (defn ^:dynamic transit-encode
   "Resolve and apply Transit's JSON/MessagePack encoding."

--- a/test/hato/conversion_test.clj
+++ b/test/hato/conversion_test.clj
@@ -1,0 +1,22 @@
+(ns hato.conversion-test
+  (:require [clojure.test :refer :all]
+            [hato.conversion :refer :all]
+            hato.middleware)
+  (:import java.io.ByteArrayInputStream
+           org.msgpack.MessagePack))
+
+(deftest test-decode-transit
+  (testing "with simple transit+json body"
+    (let [r {:body (ByteArrayInputStream. (hato.middleware/transit-encode {:a "b"} :json))
+             :content-type :application/transit+json}]
+      (is (= {:a "b"} (decode r nil)))))
+
+  (testing "with transit+json content-type but non-json body"
+    (let [r {:body (ByteArrayInputStream. (.getBytes "abc"))
+             :content-type :application/transit+json}]
+      (is (thrown-with-msg? RuntimeException #"Unrecognized token" (decode r nil)))))
+
+  (testing "with empty body"
+    (let [r {:body (ByteArrayInputStream. (.getBytes ""))
+             :content-type :application/transit+json}]
+      (is (nil? (decode r nil))))))

--- a/test/hato/middleware_test.clj
+++ b/test/hato/middleware_test.clj
@@ -5,7 +5,7 @@
             [hato.middleware :refer :all])
   (:import (java.util.zip
             GZIPOutputStream)
-           (java.io ByteArrayOutputStream InputStream)))
+           (java.io ByteArrayInputStream ByteArrayOutputStream InputStream)))
 
 (deftest test-wrap-request-timing
   (let [r ((wrap-request-timing (fn [x] (Thread/sleep 1) x)) {})]
@@ -366,3 +366,16 @@
       (is (instance? InputStream (:body r)))
       (is (re-matches #"^multipart/form-data; boundary=[a-zA-Z0-9_]+$" (-> r :headers (get "content-type"))))
       (is (nil? (:multipart r))))))
+
+(deftest test-parse-transit
+  (testing "with simple transit body"
+    (let [in (ByteArrayInputStream. (transit-encode {:a "b"} :json))]
+      (is (= {:a "b"} (parse-transit in :json)))))
+
+  (testing "with non-json body"
+    (let [in (ByteArrayInputStream. (.getBytes "abc"))]
+      (is (thrown-with-msg? RuntimeException #"Unrecognized token" (parse-transit in :json)))))
+
+  (testing "with empty body"
+    (let [in (ByteArrayInputStream. (.getBytes ""))]
+      (is (nil? (parse-transit in :json))))))


### PR DESCRIPTION
This PR prevents cases where having `:as :transit+json` with a non json body will silently swallow an exception and return nil. Also prevents situations where the server advertises the content-type of application/transit+json but returns an unparsable body which would also previously be silently ignored by the automatic decoding.

I've not created a corresponding issue, although happy to if it's helpful.

This PR also doesn't attempt to solve anything similar for the msgpack case where any bytes in the body can be interpreted as a sequence of values (i.e. it typically doesn't fail regardless of body contents and returns _some value_).