### PR TITLE
Propagate multipart exceptions and accept custom charsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,10 @@ request and returns a response. Convenience wrappers are provided for the http v
   - `:part-name` To preserve the order of entities, `:name` will be used as the part name unless `:part-name` is specified
   - `:content` The part's data. May be a `String`, `InputStream`, `Reader`, `File`, `char-array`, or a `byte-array`
   - `:file-name` The part's file name. If the `:content` is a `File`, it will use `.getName` by default but may be overridden.
-  - `:content-type` The part's content type. By default, if `:content` is a `String` it will be `text/plain; charset=UTF-8`
-                    and if `:content` is a `File` it will attempt to guess the best content type or fallback to
-                    `application/octet-stream`.
+  - `:content-type` The part's content type. The value may be a `String` such as `"text/plain; charset=utf-8"` or represented as
+    a map such as `{:mime-type "text/html"}` or `{:mime-type "text/plain" :charset "iso-8859-1"}`. If left empty, the value
+    will depend on `:content`. When `:content` is a `String`, it will be `text/plain; charset=UTF-8` and when `:content` 
+    is a `File`, it will attempt to guess the best content type or fallback to `application/octet-stream`.
 
 `headers` Map of lower case strings to header values, concatenated with ',' when multiple values for a key.
   This is presently a slight incompatibility with clj-http, which accepts keyword keys and list values.

--- a/src/hato/multipart.clj
+++ b/src/hato/multipart.clj
@@ -40,7 +40,7 @@
     "Content-Transfer-Encoding: 8bit"
     "Content-Transfer-Encoding: binary"))
 
-(def ^:private charset-pattern #".*(?i)charset\b=\s*\"?([^\";]+)\"?.*")
+(def ^:private charset-pattern #"(?i).*charset=\s*\"?([^\";]+)\"?.*")
 
 (defn- charset-from-content-type
   "Parses the charset from a content-type string. Examples:

--- a/src/hato/multipart.clj
+++ b/src/hato/multipart.clj
@@ -3,7 +3,7 @@
   (:refer-clojure :exclude [get])
   (:require [clojure.java.io :as io]
             [clojure.spec.alpha :as s])
-  (:import (java.io ByteArrayInputStream File InputStream SequenceInputStream)
+  (:import (java.io File InputStream SequenceInputStream)
            (java.net Socket URI URL)
            (java.nio.charset Charset StandardCharsets)
            (java.nio.file Files Path)
@@ -40,6 +40,8 @@
     "Content-Transfer-Encoding: 8bit"
     "Content-Transfer-Encoding: binary"))
 
+(def ^:private charset-pattern #".*(?i)charset\b=\s*\"?([^\";]+)\"?.*")
+
 (defn- charset-from-content-type
   "Parses the charset from a content-type string. Examples:
   text/html;charset=utf-8
@@ -49,9 +51,9 @@
 
   See https://www.rfc-editor.org/rfc/rfc7231"
   [content-type]
-  (second (re-matches #".*charset=\s*\"?([^\";]+)\"?.*" content-type)))
+  (second (re-matches charset-pattern content-type)))
 
-(defn- ^Charset charset-encoding
+(defn ^Charset charset-encoding
   "Determines the appropriate charset to encode a string with given the supplied content-type."
   [{:keys [content-type]}]
   (as-> content-type $

--- a/test/hato/multipart_test.clj
+++ b/test/hato/multipart_test.clj
@@ -3,7 +3,8 @@
             [hato.multipart :refer :all :as multipart]
             [clojure.spec.alpha :as s]
             [clojure.java.io :as io])
-  (:import (java.io ByteArrayOutputStream)))
+  (:import (java.io ByteArrayInputStream ByteArrayOutputStream)
+           (java.nio.charset StandardCharsets)))
 
 (deftest test-boundary
   (let [b (boundary)]
@@ -12,9 +13,13 @@
 (deftest test-body
   (let [_ (spit (io/file ".test-data") "[\"hello world\"]")
         ms [{:name "title" :content "My Awesome Picture"}
+            {:name "diffCs" :content "custom cs" :content-type "text/plain; charset=\"iso-8859-1\""}
+            {:name "expandedCs" :content "expanded cs" :content-type {:mime-type "text/plain" :charset StandardCharsets/US_ASCII}}
+            {:name "expandedCsStr" :content "expanded cs str" :content-type {:mime-type "text/plain" :charset "utf-8"}}
             {:name "Content/type" :content "image/jpeg"}
             {:name "foo.txt" :part-name "eggplant" :content "Eggplants"}
             {:name "file" :content (io/file ".test-data")}
+            {:name "is" :content (ByteArrayInputStream. (.getBytes ".test-data" "UTF-8")) :file-name "data.info"}
             {:name "data" :content (.getBytes "hi" "UTF-8") :content-type "text/plain" :file-name "data.txt"}
             {:name "jsonParam" :content (io/file ".test-data") :content-type "application/json" :file-name "data.json"}]
         b (body ms "boundary")
@@ -29,30 +34,63 @@
               "Content-Transfer-Encoding: 8bit\r\n"
               "\r\n"
               "My Awesome Picture\r\n"
+
+              "--boundary\r\n"
+              "Content-Disposition: form-data; name=\"diffCs\"\r\n"
+              "Content-Type: text/plain; charset=\"iso-8859-1\"\r\n"
+              "Content-Transfer-Encoding: 8bit\r\n"
+              "\r\n"
+              "custom cs\r\n"
+
+              "--boundary\r\n"
+              "Content-Disposition: form-data; name=\"expandedCs\"\r\n"
+              "Content-Type: text/plain; charset=US-ASCII\r\n"
+              "Content-Transfer-Encoding: 8bit\r\n"
+              "\r\n"
+              "expanded cs\r\n"
+
+              "--boundary\r\n"
+              "Content-Disposition: form-data; name=\"expandedCsStr\"\r\n"
+              "Content-Type: text/plain; charset=utf-8\r\n"
+              "Content-Transfer-Encoding: 8bit\r\n"
+              "\r\n"
+              "expanded cs str\r\n"
+
               "--boundary\r\n"
               "Content-Disposition: form-data; name=\"Content/type\"\r\n"
               "Content-Type: text/plain; charset=UTF-8\r\n"
               "Content-Transfer-Encoding: 8bit\r\n"
               "\r\n"
               "image/jpeg\r\n"
+
               "--boundary\r\n"
               "Content-Disposition: form-data; name=\"eggplant\"\r\n"
               "Content-Type: text/plain; charset=UTF-8\r\n"
               "Content-Transfer-Encoding: 8bit\r\n"
               "\r\n"
               "Eggplants\r\n"
+
               "--boundary\r\n"
               "Content-Disposition: form-data; name=\"file\"; filename=\".test-data\"\r\n"
               "Content-Type: application/octet-stream\r\n"
               "Content-Transfer-Encoding: binary\r\n"
               "\r\n"
               "[\"hello world\"]\r\n"
+
+              "--boundary\r\n"
+              "Content-Disposition: form-data; name=\"is\"; filename=\"data.info\"\r\n"
+              "Content-Type: application/octet-stream\r\n"
+              "Content-Transfer-Encoding: binary\r\n"
+              "\r\n"
+              ".test-data\r\n"
+
               "--boundary\r\n"
               "Content-Disposition: form-data; name=\"data\"; filename=\"data.txt\"\r\n"
               "Content-Type: text/plain\r\n"
               "Content-Transfer-Encoding: binary\r\n"
               "\r\n"
               "hi\r\n"
+
               "--boundary\r\n"
               "Content-Disposition: form-data; name=\"jsonParam\"; filename=\"data.json\"\r\n"
               "Content-Type: application/json\r\n"


### PR DESCRIPTION
- In the previous implementation, when uploading a large file while the remote end hangs up it would throw an unhandled exception generally in the form "Read end dead"
- In the previous implementation, when uploading a file using an InputStream for example and the underlying stream throws an exception, these exceptions would not be propagated to the HttpClient/HttpRequest and would often result in incomplete payloads arriving to the server.
- Allow setting string charset types correctly where previously it would always use UTF-8 when copying to the underlying PipedOutputStream.