### PR TITLE
Allow a header's value to be a seq of src to match clj-http and multi-valued header responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ request and returns a response. Convenience wrappers are provided for the http v
     will depend on `:content`. When `:content` is a `String`, it will be `text/plain; charset=UTF-8` and when `:content` 
     is a `File`, it will attempt to guess the best content type or fallback to `application/octet-stream`.
 
-`headers` Map of lower case strings to header values, concatenated with ',' when multiple values for a key.
-  This is presently a slight incompatibility with clj-http, which accepts keyword keys and list values.
+`headers` Map of lower case strings to a header value. A header's value may be a string or a sequence of strings when 
+  there are multiple values for a given header.
 
 `basic-auth` Performs basic authentication (sending `Basic` authorization header). Accepts `{:user "user" :pass "pass"}`
   Note that basic auth can also be passed via the `url` (e.g. `http://user:pass@moo.com`)

--- a/src/hato/client.clj
+++ b/src/hato/client.clj
@@ -187,8 +187,14 @@
 (defn- with-headers
   ^HttpRequest$Builder [builder headers]
   (reduce-kv
-   (fn [^HttpRequest$Builder b ^String hk ^String hv]
-     (.header b hk hv))
+   (fn [^HttpRequest$Builder b ^String hk hv]
+     (if (sequential? hv)
+       (reduce
+        (fn [^HttpRequest$Builder acc-b shv]
+          (.header acc-b hk (str shv)))
+        b
+        hv)
+       (.header b hk (str hv))))
    builder
    headers))
 

--- a/test/hato/client_test.clj
+++ b/test/hato/client_test.clj
@@ -1,6 +1,7 @@
 (ns hato.client-test
   (:refer-clojure :exclude [get])
-  (:require [clojure.test :refer :all]
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
             [hato.client :refer :all]
             [clojure.java.io :as io]
             [org.httpkit.server :as http-kit]
@@ -339,3 +340,23 @@
                                   (fn [req]
                                     ::response))]})]
     (is (= ::response r))))
+
+(deftest multi-value-headers
+  (testing "We can send and receive multi-value headers"
+    (with-server (fn app [req]
+                   {:status  200
+                    :headers {"foo"          ["bar" "baz"]
+                              "content-type" "application/json"}
+                    :body    (json/generate-string
+                              (-> (:headers req)
+                                  (select-keys ["a" "b"])
+                                  ;; ring spec will take multi value headers as a comma separated string.
+                                  (update "b" #(str/split % #","))))})
+      (let [response (get "http://localhost:1234" {:headers {"a" "single"
+                                                             "b" ["1" "2"]}
+                                                   :as      :json})]
+        (is (= {"content-type" "application/json"
+                "foo"          ["bar" "baz"]}
+               (select-keys (:headers response) ["foo" "content-type"])))
+        (is (= {:a "single" :b ["1" "2"]}
+               (:body response)))))))

--- a/test/hato/client_test.clj
+++ b/test/hato/client_test.clj
@@ -349,14 +349,16 @@
                               "content-type" "application/json"}
                     :body    (json/generate-string
                               (-> (:headers req)
-                                  (select-keys ["a" "b"])
+                                  (select-keys ["a" "b" "c" "d"])
                                   ;; ring spec will take multi value headers as a comma separated string.
                                   (update "b" #(str/split % #","))))})
       (let [response (get "http://localhost:1234" {:headers {"a" "single"
-                                                             "b" ["1" "2"]}
+                                                             "b" ["1" "2"]
+                                                             "c" "1,2"
+                                                             "d" 123}
                                                    :as      :json})]
         (is (= {"content-type" "application/json"
                 "foo"          ["bar" "baz"]}
                (select-keys (:headers response) ["foo" "content-type"])))
-        (is (= {:a "single" :b ["1" "2"]}
+        (is (= {:a "single" :b ["1" "2"] :c "1,2" :d "123"}
                (:body response)))))))


### PR DESCRIPTION
Right now if you receive a response with multiple values for the same header, it comes back like so:

```clojure
{:headers {"content-type" "application/json"
                  "foo"          ["bar" "baz"]}}
```

In my opinion it's a bit inconsistent to not allow the same format for a request as well. This allows the caller to either use an array (which will send multiple header entries) or a comma separate list of values which are both acceptable per the RFC. This also is a bit more generous with the data type of the header value so you can pass something like a number which will be coerced to a string. I'm fine removing the coercion too if you feel strongly otherwise I just know I've wanted to set things like x-retry-count (number), x-user-id (uuid), etc and would be nice if it "just worked".