### PR TITLE
Capitalise content type HTTP header

### DIFF
--- a/src/hato/middleware.clj
+++ b/src/hato/middleware.clj
@@ -291,7 +291,7 @@
           ct (if character-encoding
                (str ctv "; charset=" character-encoding)
                ctv)]
-      (update-in req [:headers] assoc "content-type" ct))
+      (update-in req [:headers] assoc "Content-Type" ct))
     req))
 
 (defn wrap-content-type


### PR DESCRIPTION
Yesterday this started causing the Notion API to return incorrect results, I assume due a change on their side. 